### PR TITLE
Bump junit from 1.1.3 to 1.1.4

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -83,7 +83,7 @@ ext {
             google_truth      : 'com.google.truth:truth:1.1.3',
             robolectric       : 'org.robolectric:robolectric:4.9',
             androidx_test_core: 'androidx.test:core:1.4.0',
-            androidx_junit    : 'androidx.test.ext:junit:1.1.3',
+            androidx_junit    : 'androidx.test.ext:junit:1.1.4',
             androidx_espresso : 'androidx.test.espresso:espresso-core:3.4.0',
     ]
 }


### PR DESCRIPTION
Bumps junit from 1.1.3 to 1.1.4.

---
updated-dependencies:
- dependency-name: androidx.test.ext:junit dependency-type: direct:production update-type: version-update:semver-patch ...

Signed-off-by: dependabot[bot] <support@github.com>