### PR TITLE
Bump espresso-core from 3.4.0 to 3.5.0

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -84,6 +84,6 @@ ext {
             robolectric       : 'org.robolectric:robolectric:4.9',
             androidx_test_core: 'androidx.test:core:1.4.0',
             androidx_junit    : 'androidx.test.ext:junit:1.1.3',
-            androidx_espresso : 'androidx.test.espresso:espresso-core:3.4.0',
+            androidx_espresso : 'androidx.test.espresso:espresso-core:3.5.0',
     ]
 }


### PR DESCRIPTION
Bumps espresso-core from 3.4.0 to 3.5.0.

---
updated-dependencies:
- dependency-name: androidx.test.espresso:espresso-core dependency-type: direct:production update-type: version-update:semver-minor ...

Signed-off-by: dependabot[bot] <support@github.com>